### PR TITLE
Update libfreetype package version in packages.txt

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -4,7 +4,7 @@ libtesseract-dev
 build-essential
 cmake
 pkg-config
-libfreetype6-dev
+libfreetype-dev
 libharfbuzz-dev
 libjpeg-dev
 libopenjp2-7-dev


### PR DESCRIPTION
Further changes may be required depending on whether the python packages in requirements.txt can be compiled from source using this libfreetype version or not.